### PR TITLE
StateCheckpointers added for efficient state serialization

### DIFF
--- a/src/main/java/streamkv/api/TimestampedKVStore.java
+++ b/src/main/java/streamkv/api/TimestampedKVStore.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
 import streamkv.operator.TimestampedKVStoreOperator;
 import streamkv.types.KVOperation;
+import streamkv.types.KVOperationTypeInfo.KVOpSerializer;
 
 /**
  * {@link KVStore} implementation that executes operations in time order. Time
@@ -52,7 +53,7 @@ public class TimestampedKVStore<K, V> extends AsyncKVStore<K, V> {
 	}
 	
 	@Override
-	protected OneInputStreamOperator<KVOperation<K, V>, KVOperation<K, V>> getKVOperator() {
-		return new TimestampedKVStoreOperator<>();
+	protected OneInputStreamOperator<KVOperation<K, V>, KVOperation<K, V>> getKVOperator(KVOpSerializer<K, V> serializer) {
+		return new TimestampedKVStoreOperator<>(serializer);
 	}
 }

--- a/src/main/java/streamkv/benchmark/TimestampedKVLocalBenchmark.java
+++ b/src/main/java/streamkv/benchmark/TimestampedKVLocalBenchmark.java
@@ -33,7 +33,7 @@ public class TimestampedKVLocalBenchmark extends LocalBenchmark {
 
 	private static final long serialVersionUID = 1L;
 	
-	private static final long ELEMENTS_PER_QUERY = 10_000_000L;
+	private static final long ELEMENTS_PER_QUERY = 1_000_000L;
 	private static final int NUM_KEYS = 1000;
 	private static final int KEYS_PER_MGET = 10;
 	private static final int WATERMARK_FREQUENCY = 1000;

--- a/src/main/java/streamkv/operator/MultiGetMerger.java
+++ b/src/main/java/streamkv/operator/MultiGetMerger.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamkv.operator;
+
+import java.io.IOException;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.state.OperatorState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import streamkv.operator.checkpointing.MergeStateCheckpointer;
+import streamkv.types.KVOperation;
+import streamkv.types.KVOperation.KVOperationType;
+
+/**
+ * {@link FlatMapFunction} to merge the different key-value pairs for multiget
+ * operations.
+ * 
+ * @param <K>
+ *            Type of the keys.
+ * @param <V>
+ *            Type of the values.
+ */
+@SuppressWarnings("rawtypes")
+public class MultiGetMerger<K, V> extends RichFlatMapFunction<KVOperation<K, V>, Tuple2[]> {
+	private static final long serialVersionUID = 1L;
+
+	private OperatorState<Tuple2<Integer, Tuple2[]>> merged;
+	private TypeSerializer keySerializer;
+	private TypeSerializer valueSerializer;
+
+	public MultiGetMerger(TypeSerializer keySerializer, TypeSerializer valueSerializer) {
+		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
+	}
+
+	@Override
+	public void flatMap(KVOperation<K, V> next, Collector<Tuple2[]> out) throws Exception {
+		Tuple2<Integer, Tuple2[]> partial = merged.value();
+		Object key = next.getType() == KVOperationType.MGETRES ? next.getKey() : next.getRecord();
+		short numKeys = next.getNumKeys();
+
+		if (numKeys == 0) {
+			throw new RuntimeException("Number of keys must be at least 1");
+		}
+
+		if (partial.f0 == -1) {
+			partial.f0 = (int) numKeys - 1;
+			partial.f1 = new Tuple2[numKeys];
+			partial.f1[0] = Tuple2.of(key, next.getValue());
+
+		} else {
+			partial.f0 -= 1;
+			partial.f1[numKeys - partial.f0 - 1] = Tuple2.of(key, next.getValue());
+		}
+
+		if (partial.f0 == 0) {
+			out.collect(partial.f1);
+			merged.update(null);
+		} else {
+			merged.update(partial);
+		}
+
+	}
+
+	@Override
+	public void open(Configuration conf) throws IOException {
+		merged = getRuntimeContext().getOperatorState("merged",
+				Tuple2.<Integer, Tuple2[]> of(-1, new Tuple2[0]), true,
+				new MergeStateCheckpointer<>(keySerializer, valueSerializer));
+	}
+}

--- a/src/main/java/streamkv/operator/checkpointing/KVMapCheckpointer.java
+++ b/src/main/java/streamkv/operator/checkpointing/KVMapCheckpointer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamkv.operator.checkpointing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map.Entry;
+
+import org.apache.flink.api.common.state.StateCheckpointer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.ByteArrayInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+
+/**
+ * {@link StateCheckpointer} for efficient serialization of the stored key-value
+ * pairs, to reduce the checkpointing overhead.
+ * 
+ * @param <K>
+ *            Type of the keys.
+ * @param <V>
+ *            Type of the values.
+ */
+public class KVMapCheckpointer<K, V> implements StateCheckpointer<HashMap<K, V>, byte[]> {
+
+	private TypeSerializer<K> keySerializer;
+	private TypeSerializer<V> valueSerializer;
+
+	public KVMapCheckpointer(TypeSerializer<K> keySerializer, TypeSerializer<V> valueSerializer) {
+		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
+	}
+
+	@Override
+	public byte[] snapshotState(HashMap<K, V> stateMap, long checkpointId, long checkpointTimestamp) {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream(stateMap.size() * 16);
+		DataOutputView out = new OutputViewDataOutputStreamWrapper(new DataOutputStream(bos));
+		try {
+			out.writeInt(stateMap.size());
+			for (Entry<K, V> kv : stateMap.entrySet()) {
+				keySerializer.serialize(kv.getKey(), out);
+				valueSerializer.serialize(kv.getValue(), out);
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to write snapshot", e);
+		}
+		return bos.toByteArray();
+	}
+
+	@Override
+	public HashMap<K, V> restoreState(byte[] stateSnapshot) {
+		ByteArrayInputView in = new ByteArrayInputView(stateSnapshot);
+
+		HashMap<K, V> returnMap = new HashMap<>();
+		try {
+			int size = in.readInt();
+			for (int i = 0; i < size; i++) {
+				returnMap.put(keySerializer.deserialize(in), valueSerializer.deserialize(in));
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to read snapshot", e);
+		}
+
+		return returnMap;
+	}
+
+}

--- a/src/main/java/streamkv/operator/checkpointing/MergeStateCheckpointer.java
+++ b/src/main/java/streamkv/operator/checkpointing/MergeStateCheckpointer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamkv.operator.checkpointing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.flink.api.common.state.StateCheckpointer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.ByteArrayInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+
+/**
+ * {@link StateCheckpointer} for the efficient serialization of the intermediate
+ * merged values for multiget operations.
+ * 
+ * @param <K>
+ *            Type of the keys.
+ * @param <V>
+ *            Type of the values.
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class MergeStateCheckpointer<K, V> implements StateCheckpointer<Tuple2<Integer, Tuple2[]>, byte[]> {
+
+	TypeSerializer keySerializer;
+	TypeSerializer valueSerializer;
+
+	public MergeStateCheckpointer(TypeSerializer keySerializer, TypeSerializer valueSerializer) {
+		super();
+		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
+	}
+
+	@Override
+	public byte[] snapshotState(Tuple2<Integer, Tuple2[]> state, long checkpointId, long checkpointTimestamp) {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream(4 + state.f1.length * (12));
+		DataOutputView out = new OutputViewDataOutputStreamWrapper(new DataOutputStream(bos));
+		try {
+			out.writeInt(state.f0);
+			out.writeInt(state.f1.length);
+			for (Tuple2 t : state.f1) {
+				keySerializer.serialize(t.f0, out);
+				valueSerializer.serialize(t.f1, out);
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to write snapshot, e");
+		}
+		return bos.toByteArray();
+	}
+
+	@Override
+	public Tuple2<Integer, Tuple2[]> restoreState(byte[] stateSnapshot) {
+		ByteArrayInputView in = new ByteArrayInputView(stateSnapshot);
+
+		Tuple2<Integer, Tuple2[]> outTuple = new Tuple2<>();
+		try {
+			outTuple.f0 = in.readInt();
+
+			int len = in.readInt();
+			Tuple2[] arr = new Tuple2[len];
+			for (int i = 0; i < len; i++) {
+				arr[i] = Tuple2.of(keySerializer.deserialize(in), valueSerializer.deserialize(in));
+			}
+			outTuple.f1 = arr;
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to read snapshot", e);
+		}
+		return outTuple;
+	}
+}

--- a/src/main/java/streamkv/operator/checkpointing/PendingOperationCheckpointer.java
+++ b/src/main/java/streamkv/operator/checkpointing/PendingOperationCheckpointer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamkv.operator.checkpointing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.apache.flink.api.common.state.StateCheckpointer;
+import org.apache.flink.api.java.typeutils.runtime.ByteArrayInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.OutputViewDataOutputStreamWrapper;
+
+import streamkv.operator.TimestampedKVStoreOperator;
+import streamkv.types.KVOperation;
+import streamkv.types.KVOperationTypeInfo.KVOpSerializer;
+
+/**
+ * {@link StateCheckpointer} for the efficient serialization of the buffered
+ * pending {@link KVOperation}s for {@link TimestampedKVStoreOperator}s used to
+ * reduce the checkpointing overhead.
+ * 
+ * @param <K>
+ *            Type of the keys.
+ * @param <V>
+ *            Type of the values.
+ */
+public class PendingOperationCheckpointer<K, V> implements
+		StateCheckpointer<TreeMap<Long, List<KVOperation<K, V>>>, byte[]> {
+
+	private KVOpSerializer<K, V> opSerializer;
+
+	public PendingOperationCheckpointer(KVOpSerializer<K, V> opSerializer) {
+		this.opSerializer = opSerializer;
+	}
+
+	@Override
+	public byte[] snapshotState(TreeMap<Long, List<KVOperation<K, V>>> pending, long checkpointId,
+			long checkpointTimestamp) {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream(pending.size() * 24);
+		DataOutputView out = new OutputViewDataOutputStreamWrapper(new DataOutputStream(bos));
+		try {
+			out.writeInt(pending.size());
+			for (Entry<Long, List<KVOperation<K, V>>> pendingEntry : pending.entrySet()) {
+				out.writeLong(pendingEntry.getKey());
+				List<KVOperation<K, V>> pendingList = pendingEntry.getValue();
+				out.writeInt(pendingList.size());
+				for (KVOperation<K, V> op : pendingList) {
+					opSerializer.serialize(op, out);
+				}
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to write snapshot", e);
+		}
+		return bos.toByteArray();
+	}
+
+	@Override
+	public TreeMap<Long, List<KVOperation<K, V>>> restoreState(byte[] stateSnapshot) {
+		ByteArrayInputView in = new ByteArrayInputView(stateSnapshot);
+
+		TreeMap<Long, List<KVOperation<K, V>>> returnMap = new TreeMap<>();
+		try {
+			int mapSize = in.readInt();
+			for (int i = 0; i < mapSize; i++) {
+				long ts = in.readLong();
+				int listSize = in.readInt();
+				LinkedList<KVOperation<K, V>> pending = new LinkedList<>();
+				for (int j = 0; j < listSize; j++) {
+					pending.add(opSerializer.deserialize(in));
+				}
+				returnMap.put(ts, pending);
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to read snapshot", e);
+		}
+
+		return returnMap;
+	}
+
+}

--- a/src/main/java/streamkv/types/KVOperationTypeInfo.java
+++ b/src/main/java/streamkv/types/KVOperationTypeInfo.java
@@ -140,8 +140,8 @@ public class KVOperationTypeInfo<K, V> extends TypeInformation<KVOperation<K, V>
 	public static class KVOpSerializer<K, V> extends TypeSerializer<KVOperation<K, V>> {
 
 		private static final long serialVersionUID = 1L;
-		private TypeSerializer<K> keySerializer;
-		private TypeSerializer<V> valueSerializer;
+		public TypeSerializer<K> keySerializer;
+		public TypeSerializer<V> valueSerializer;
 		private Map<Integer, Tuple2<TypeSerializer, KeySelector>> selectors;
 		private Map<Integer, ReduceFunction<V>> reducers;
 

--- a/src/main/java/streamkv/types/KVTypeInfo.java
+++ b/src/main/java/streamkv/types/KVTypeInfo.java
@@ -85,8 +85,8 @@ public class KVTypeInfo<K, V> extends TypeInformation<Tuple2<K, V>> {
 	public static class KVSerializer<K, V> extends TypeSerializer<Tuple2<K, V>> {
 
 		private static final long serialVersionUID = 1L;
-		TypeSerializer<K> keySerializer;
-		TypeSerializer<V> valueSerializer;
+		public final TypeSerializer<K> keySerializer;
+		public final TypeSerializer<V> valueSerializer;
 
 		public KVSerializer(TypeSerializer<K> keySerializer, TypeSerializer<V> valueSerializer) {
 			this.keySerializer = keySerializer;

--- a/src/test/java/streamkv/operator/TimestampedKVStoreOperatorTest.java
+++ b/src/test/java/streamkv/operator/TimestampedKVStoreOperatorTest.java
@@ -17,14 +17,16 @@
 
 package streamkv.operator;
 
+import static streamkv.operator.AsyncKVStoreOperatorTest.reducer;
 import static streamkv.operator.AsyncKVStoreOperatorTest.selector;
-import static streamkv.operator.AsyncKVStoreOperatorTest.update;
 import static streamkv.operator.AsyncKVStoreOperatorTest.selectorGet;
 import static streamkv.operator.AsyncKVStoreOperatorTest.selectorMultiGet;
+import static streamkv.operator.AsyncKVStoreOperatorTest.update;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -32,20 +34,16 @@ import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.junit.Test;
 
 import streamkv.types.KVOperation;
+import streamkv.types.KVOperationTypeInfo.KVOpSerializer;
 
 public class TimestampedKVStoreOperatorTest {
-
-	ReduceFunction<Integer> reducer = new ReduceFunction<Integer>() {
-		@Override
-		public Integer reduce(Integer t1, Integer t2) throws Exception {
-			return t1 + t2;
-		}
-	};
 
 	@Test
 	public void testKVOperator() throws Exception {
 
-		AsyncKVStoreOperator<String, Integer> operator = new TimestampedKVStoreOperator<>();
+		AsyncKVStoreOperator<String, Integer> operator = new TimestampedKVStoreOperator<>(
+				new KVOpSerializer<String, Integer>(StringSerializer.INSTANCE, IntSerializer.INSTANCE, null,
+						null, null));
 
 		OneInputStreamOperatorTestHarness<KVOperation<String, Integer>, KVOperation<String, Integer>> testHarness = new OneInputStreamOperatorTestHarness<>(
 				operator);
@@ -66,15 +64,15 @@ public class TimestampedKVStoreOperatorTest {
 
 		testHarness.processWatermark(new Watermark(6));
 
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>remove(3, "d"), 13));
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>get(2, "1"), 9));
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> remove(3, "d"), 13));
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> get(2, "1"), 9));
 		testHarness.processElement(new StreamRecord<>(KVOperation.put(0, "c", 3), 7));
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>get(2, "c"), 10));
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> get(2, "c"), 10));
 		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> get(1, "a"), 8));
 
 		testHarness.processWatermark(new Watermark(11));
 
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>multiGet(5, "a",
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> multiGet(5, "a",
 				(short) 5, 1L), 16));
 		testHarness.processElement(new StreamRecord<>(selectorGet(4, 1, selector), 14));
 		testHarness.processElement(new StreamRecord<>(selectorGet(4, 2, selector), 15));
@@ -85,14 +83,11 @@ public class TimestampedKVStoreOperatorTest {
 		testHarness.processWatermark(new Watermark(18));
 
 		testHarness.processElement(new StreamRecord<>(update(7, "z", 1, reducer), 19));
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>get(8, "z"), 20));
-		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer>get(8, "z"), 22));
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> get(8, "z"), 20));
+		testHarness.processElement(new StreamRecord<>(KVOperation.<String, Integer> get(8, "z"), 22));
 
 		testHarness.processWatermark(new Watermark(22));
 
-		
-		
-		
 		expectedOutput.add(new StreamRecord<>(KVOperation.getRes(1, "a", 1), 3));
 		expectedOutput.add(new StreamRecord<>(KVOperation.getRes(1, "1", 2), 4));
 		expectedOutput.add(new StreamRecord<>(KVOperation.getRes(2, "c", null), 5));
@@ -109,7 +104,7 @@ public class TimestampedKVStoreOperatorTest {
 		expectedOutput.add(new StreamRecord<>(KVOperation.selectorMultiGetRes(6, 1, 2, (short) 5, 2L), 17));
 		expectedOutput.add(new StreamRecord<>(KVOperation.getRes(8, "z", 1), 20));
 		expectedOutput.add(new StreamRecord<>(KVOperation.getRes(8, "z", 11), 22));
-		
+
 		TestHarnessUtil
 				.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
 	}

--- a/src/test/java/streamkv/operator/checkpointing/StateCheckpointerTests.java
+++ b/src/test/java/streamkv/operator/checkpointing/StateCheckpointerTests.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamkv.operator.checkpointing;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TreeMap;
+
+import org.apache.flink.api.common.state.StateCheckpointer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.InstantiationUtil;
+import org.junit.Test;
+
+import scala.util.Random;
+import streamkv.types.KVOperation;
+import streamkv.util.RandomKVOperationGenerator;
+
+public class StateCheckpointerTests {
+
+	@Test
+	public void testKVMapCheckpointer() throws IOException, ClassNotFoundException {
+
+		StateCheckpointer<HashMap<Integer, String>, byte[]> cp = new KVMapCheckpointer<Integer, String>(
+				IntSerializer.INSTANCE, StringSerializer.INSTANCE);
+
+		HashMap<Integer, String> state = new HashMap<>();
+		state.put(1, "a");
+		state.put(2, "b");
+		state.put(3, "c");
+		state.put(4, "d");
+
+		byte[] serializableState = cp.snapshotState(state, 0, 0);
+		byte[] serialized = InstantiationUtil.serializeObject(serializableState);
+
+		assertEquals(state, cp.restoreState((byte[]) InstantiationUtil.deserializeObject(serialized, Thread
+				.currentThread().getContextClassLoader())));
+
+	}
+
+	@Test
+	public void testPendingOpCheckpointer() throws IOException, ClassNotFoundException {
+
+		Random rnd = new Random();
+		RandomKVOperationGenerator opGen = new RandomKVOperationGenerator();
+
+		StateCheckpointer<TreeMap<Long, List<KVOperation<Integer, Integer>>>, byte[]> cp = new PendingOperationCheckpointer<>(
+				RandomKVOperationGenerator.opSerializer);
+
+		TreeMap<Long, List<KVOperation<Integer, Integer>>> pending = new TreeMap<>();
+		for (int i = 0; i < 1000; i++) {
+			LinkedList<KVOperation<Integer, Integer>> ops = new LinkedList<>(opGen.generateList(rnd
+					.nextInt(10)));
+			pending.put(rnd.nextLong(), ops);
+		}
+
+		byte[] serializableState = cp.snapshotState(pending, 0, 0);
+		byte[] serialized = InstantiationUtil.serializeObject(serializableState);
+
+		assertEquals(pending, cp.restoreState((byte[]) InstantiationUtil.deserializeObject(serialized, Thread
+				.currentThread().getContextClassLoader())));
+
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void testMergeStateCheckpointer() throws IOException, ClassNotFoundException {
+
+		StateCheckpointer<Tuple2<Integer, Tuple2[]>, byte[]> cp = new MergeStateCheckpointer<>(
+				IntSerializer.INSTANCE, StringSerializer.INSTANCE);
+
+		Tuple2<Integer, Tuple2[]> state = Tuple2.of(5, new Tuple2[] { Tuple2.of(2, "a"), Tuple2.of(4, "b") });
+
+		byte[] serializableState = cp.snapshotState(state, 0, 0);
+		byte[] serialized = InstantiationUtil.serializeObject(serializableState);
+
+		Tuple2<Integer, Tuple2[]> restored = cp.restoreState((byte[]) InstantiationUtil.deserializeObject(
+				serialized, Thread.currentThread().getContextClassLoader()));
+		assertEquals(state.f0, restored.f0);
+		assertArrayEquals(state.f1, restored.f1);
+	}
+}

--- a/src/test/java/streamkv/util/RandomKVOperationGenerator.java
+++ b/src/test/java/streamkv/util/RandomKVOperationGenerator.java
@@ -18,6 +18,8 @@
 package streamkv.util;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
@@ -37,7 +39,7 @@ public class RandomKVOperationGenerator {
 
 	private Random rnd = new Random();
 	@SuppressWarnings("rawtypes")
-	private KVOpSerializer<Integer, Integer> serializer = new KVOpSerializer<>(new IntSerializer(),
+	public static KVOpSerializer<Integer, Integer> opSerializer = new KVOpSerializer<>(new IntSerializer(),
 			new IntSerializer(), new HashMap<Integer, ReduceFunction<Integer>>(), ImmutableMap.of(0,
 					Tuple2.<TypeSerializer, KeySelector> of(new StringSerializer(), null)), null);
 
@@ -53,8 +55,19 @@ public class RandomKVOperationGenerator {
 		return output;
 	}
 
+	public List<KVOperation<Integer, Integer>> generateList(int numOperations) {
+
+		List<KVOperation<Integer, Integer>> ops = new LinkedList<>();
+
+		for (int i = 0; i < numOperations; i++) {
+			ops.add(generateOp());
+		}
+
+		return ops;
+	}
+
 	public KVOpSerializer<Integer, Integer> getSerializer() {
-		return serializer;
+		return opSerializer;
 	}
 
 	public KVOperation<Integer, Integer> generateOp() {


### PR DESCRIPTION
This PR adds proper StateCheckpointers (and tests for these) for the OperatorStates held by the KVStore operators:
- The HashMap of Key-Value pairs
- The Treemap of pending operations for TimeStamped KV stores
- The partially merged values for multiget operations

These operators now also use the proper Flink serializers allowing for key-value types that don't implement the Java Serializable interface.

**_The PR is pending on an already pushed fix to Flink that resolves an issue with the serialization of default state values for partitioned operator states.**_
